### PR TITLE
OpenAPI: Include type key in schema object properties dict. (#7169)

### DIFF
--- a/rest_framework/schemas/openapi.py
+++ b/rest_framework/schemas/openapi.py
@@ -413,6 +413,7 @@ class AutoSchema(ViewInspector):
             properties[field.field_name] = schema
 
         result = {
+            'type': 'object',
             'properties': properties
         }
         if required:

--- a/tests/schemas/test_openapi.py
+++ b/tests/schemas/test_openapi.py
@@ -335,6 +335,7 @@ class TestOperationIntrospection(TestCase):
                         'schema': {
                             'type': 'array',
                             'items': {
+                                'type': 'object',
                                 'properties': {
                                     'text': {
                                         'type': 'string',
@@ -386,6 +387,7 @@ class TestOperationIntrospection(TestCase):
                             'item': {
                                 'type': 'array',
                                 'items': {
+                                    'type': 'object',
                                     'properties': {
                                         'text': {
                                             'type': 'string',
@@ -532,6 +534,7 @@ class TestOperationIntrospection(TestCase):
                 'content': {
                     'application/json': {
                         'schema': {
+                            'type': 'object',
                             'properties': {
                                 'text': {
                                     'type': 'string',


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
